### PR TITLE
HTTPs support for connecting to z/OS Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   - [Installing](#installing)
   - [Usage](#usage)
     - [Connecting to z/OS Connect](#connecting-to-zos-connect)
+      - [HTTPs Support](#https-support)
     - [Retrieve a list of services](#retrieve-a-list-of-services)
     - [Get a service](#get-a-service)
     - [Invoke a service](#invoke-a-service)
@@ -43,9 +44,28 @@ npm install zosconnect-node
 ```js
 var ZosConnect = require('zosconnect-node');
 var options = {
-   uri:'http://mainframe:8080', /*required*/
+   uri:'http://mainframe:8080'
 }
 var zosconnect = new ZosConnect(options);
+```
+The `options` object matches exactly the options described by the [request/request](https://github.com/request/request) module. The uri parameter is mandatory.
+
+##### HTTPs Support
+Create the options object with locations for the CA certificate file and optionally the client certificate and client private key (if using client authentication). If the strictSSL option is set to false then invalid SSL certificates can be used which may be of use in development environments.
+```js
+var fs = require('fs');
+var path = require('path');
+var caFile = path.resolve(__dirname, 'ca.pem');
+var certFile = path.resolve(__dirname, 'cert.pem');
+var keyFile = path.resolve(__dirname, 'key.pem');
+var options = {
+   uri:'https://mainframe:9443',
+   ca: fs.readFileSync(caFile),
+   cert: fs.readFileSync(certFile),
+   key: fs.readFileSync(keyFile),
+   passphrase: 'passw0rd',
+   strictSSL: true
+}
 ```
 
 #### Retrieve a list of services

--- a/index.js
+++ b/index.js
@@ -16,16 +16,24 @@ limitations under the License.
 
 var request = require('request');
 var async = require('async');
+var extend = require('extend');
 var Service = require('./service.js');
+
+var defaultOptions = {
+   strictSSL: true
+}
 
 module.exports = function(options){
     if(options.uri == null){
         throw new Error('Required uri not specified');
     }
-    this.options = options;
+    this.options = extend(defaultOptions, options);
 
     this.getServices = function(callback){
-        request.get(this.options.uri + '/zosConnect/services', function(error, response, body){
+        var options = {};
+        options = extend(options, this.options);
+        options.uri += '/zosConnect/services';
+        request.get(options, function(error, response, body){
             if(error){
                 callback(error, null);
             } else if(response.statusCode != 200){
@@ -48,14 +56,18 @@ module.exports = function(options){
     }
 
     this.getService = function(serviceName, callback){
-        request.get(this.options.uri + '/zosConnect/services/' + serviceName, function(error, response, body){
+        var self = this;
+        var options = {};
+        options = extend(options, this.options);
+        options.uri += '/zosConnect/services/' + serviceName;
+        request.get(options, function(error, response, body){
             if(error){
                 callback(error, null);
             } else if(response.statusCode != 200){
                 callback(new Error('Unable to get service (' + response.statusCode + ')'), null);
             } else {
                 var serviceData = JSON.parse(body);
-                callback(null, new Service(this.uri, serviceName, serviceData.zosConnect.serviceInvokeURL));
+                callback(null, new Service(options, serviceName, serviceData.zosConnect.serviceInvokeURL));
             }
         })
     }

--- a/index.js
+++ b/index.js
@@ -56,7 +56,6 @@ module.exports = function(options){
     }
 
     this.getService = function(serviceName, callback){
-        var self = this;
         var options = {};
         options = extend(options, this.options);
         options.uri += '/zosConnect/services/' + serviceName;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "async": "1.4.2",
-    "request": "2.61.0"
+    "request": "2.61.0",
+    "extend": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "2.3.0",

--- a/service.js
+++ b/service.js
@@ -15,23 +15,28 @@ limitations under the License.
 */
 
 var request = require('request');
+var extend = require('extend');
 
-module.exports = function(uri, serviceName, invokeUri){
-    this.uri = uri;
+module.exports = function(options, serviceName, invokeUri){
+    this.options = options;
     this.serviceName = serviceName;
     this.invokeUri = invokeUri;
 
     this.invoke = function(data, callback){
-        request(
-            { method: 'PUT'
-            , uri: this.invokeUri
-            , json: true
-            , body: data
-            }, callback)
+        var options = {};
+        options = extend(options, this.options);
+        options.method = 'PUT';
+        options.uri = this.invokeUri;
+        options.json = true;
+        options.body = data;
+        request(options, callback)
     }
 
     this.getRequestSchema = function(callback){
-        request.get(this.uri.href + '?action=getRequestSchema', function(error, response, body){
+        var options = {};
+        options = extend(options, this.options);
+        options.uri += '?action=getRequestSchema';
+        request.get(options, function(error, response, body){
             if(error) {
                 callback(error, null)
             } else if(response.statusCode != 200){
@@ -43,7 +48,10 @@ module.exports = function(uri, serviceName, invokeUri){
     }
 
     this.getResponseSchema = function(callback){
-        request.get(this.uri.href + '?action=getResponseSchema', function(error, response, body){
+      var options = {};
+      options = extend(options, this.options);
+      options.uri += '?action=getResponseSchema';
+      request.get(options, function(error, response, body){
             if(error){
                 callback(error, null);
             } else if(response.statusCode != 200){

--- a/test/service.js
+++ b/test/service.js
@@ -21,7 +21,7 @@ var url = require('url');
 
 var service = require('../service.js');
 describe('service', function(){
-    var dateTimeService = new service(url.parse('http://test:9080/zosConnect/services/dateTimeService'), 'dateTimeService', 'http://test:9080/zosConnect/services/dateTimeService?action=invoke');
+    var dateTimeService = new service({uri: 'http://test:9080/zosConnect/services/dateTimeService'}, 'dateTimeService', 'http://test:9080/zosConnect/services/dateTimeService?action=invoke');
     describe('#invoke', function(){
         it('should invoke the service', function(done){
             nock('http://test:9080')


### PR DESCRIPTION
Resolves #2 

Supports the passing of an https:// uri with associated keys and certificates for secure connectivity to z/OS Connect.

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>