### PR TITLE
Exclude coverage/** from jscs testing

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,5 @@
 {
 	"preset": "airbnb",
-	"maxErrors": 200
+	"maxErrors": 200,
+	"excludeFiles": ["coverage/**"]
 }


### PR DESCRIPTION
Resolves #8 by excluding local folders that aren't ours, these are generally .gitignore'd

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>