### PR TITLE
Improve error checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ var defaultOptions = {
 };
 
 module.exports = function(options) {
+  if (options == null) {
+    throw new Error('An options object is required');
+  }
+
   if (options.uri == null) {
     throw new Error('Required uri not specified');
   }

--- a/index.js
+++ b/index.js
@@ -28,8 +28,15 @@ module.exports = function(options) {
     throw new Error('An options object is required');
   }
 
+  if (options.uri == null && options.url == null) {
+    throw new Error('Required uri or url not specified');
+  }
+
   if (options.uri == null) {
-    throw new Error('Required uri not specified');
+    var uri = options.url.protocol;
+    uri += '//';
+    uri += options.url.host;
+    options.uri = uri;
   }
 
   this.options = extend(defaultOptions, options);

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ require('mocha-jscs')();
 var assert = require('assert');
 var nock = require('nock');
 var should = require('should');
+var url = require('url');
 
 var ZosConnect = require('../index.js');
 
@@ -29,8 +30,8 @@ describe('zosconnect', function() {
       done();
     });
 
-    it('should throw an error if no uri specified', function(done) {
-      (function() {new ZosConnect({});}).should.throw(new Error('Required uri not specified'));
+    it('should throw an error if no uri or url specified', function(done) {
+      (function() {new ZosConnect({});}).should.throw(new Error('Required uri or url not specified'));
       done();
     });
   });
@@ -38,6 +39,26 @@ describe('zosconnect', function() {
   describe('#getservices', function() {
     it('should return a list of services', function(done) {
       var zosconnect = new ZosConnect({uri:'http://test:9080'});
+      nock('http://test:9080')
+          .get('/zosConnect/services')
+                .reply(200, {
+                  zosConnectServices: [
+                        {
+                          ServiceDescription: 'Get the date and time from the server',
+                          ServiceName: 'dateTimeService',
+                          ServiceProvider: 'zOSConnect Reference Service Provider',
+                          ServiceURL: 'http://192.168.99.100:9080/zosConnect/services/dateTimeService',
+                        },
+                    ],
+                });
+      zosconnect.getServices(function(error, services) {
+        services[0].should.equal('dateTimeService');
+        done(error);
+      });
+    });
+
+    it('should return a list of services (url in ctor)', function(done) {
+      var zosconnect = new ZosConnect({url: url.parse('http://test:9080')});
       nock('http://test:9080')
           .get('/zosConnect/services')
                 .reply(200, {

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,12 @@ var ZosConnect = require('../index.js');
 
 describe('zosconnect', function() {
   describe('#ctor', function() {
-    it('should throw an error', function(done) {
+    it('should throw an error for no object', function(done) {
+      (function() {new ZosConnect();}).should.throw(new Error('An options object is required'));
+      done();
+    });
+
+    it('should throw an error if no uri specified', function(done) {
       (function() {new ZosConnect({});}).should.throw(new Error('Required uri not specified'));
       done();
     });


### PR DESCRIPTION
Improve the error checking in the zosconnect constructor and allow the user to make use of the URL element of the options object instead of the URI element.

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>