### PR TITLE
Add node 4.0 and 4.1 to CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+  - "4.1"
+  - "4.0"
   - "0.12"
   - "iojs"


### PR DESCRIPTION
Updating travis config to test against latest versions of node.js

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>