### PR TITLE
Specify license in SPDX format

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
     "z/OS"
   ],
   "author": "Andrew Smithson",
-  "license": "Apache"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Resolves #12 by updating the license field in package.json

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>