### PR TITLE
Update test syntax for new jscs rules

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,7 @@ describe('zosconnect', function() {
 
   describe('#getservices', function() {
     it('should return a list of services', function(done) {
-      var zosconnect = new ZosConnect({uri:'http://test:9080'});
+      var zosconnect = new ZosConnect({ uri:'http://test:9080' });
       nock('http://test:9080')
           .get('/zosConnect/services')
                 .reply(200, {
@@ -58,7 +58,7 @@ describe('zosconnect', function() {
     });
 
     it('should return a list of services (url in ctor)', function(done) {
-      var zosconnect = new ZosConnect({url: url.parse('http://test:9080')});
+      var zosconnect = new ZosConnect({ url: url.parse('http://test:9080') });
       nock('http://test:9080')
           .get('/zosConnect/services')
                 .reply(200, {
@@ -78,7 +78,7 @@ describe('zosconnect', function() {
     });
 
     it('should return an error for a security problem', function(done) {
-      var zosconnect = new ZosConnect({uri:'http://test:9080'});
+      var zosconnect = new ZosConnect({ uri:'http://test:9080' });
       nock('http://test:9080')
           .get('/zosConnect/services')
           .reply(403);
@@ -90,7 +90,7 @@ describe('zosconnect', function() {
     });
 
     it('should return an error', function(done) {
-      var zosconnect = new ZosConnect({uri:'http://test:9080'});
+      var zosconnect = new ZosConnect({ uri:'http://test:9080' });
       nock('http://test:9080')
           .get('/zosConnect/services')
           .replyWithError('bad things occurred');
@@ -104,7 +104,7 @@ describe('zosconnect', function() {
 
   describe('#getservice', function() {
     it('should return a service', function(done) {
-      var zosconnect = new ZosConnect({uri:'http://test:9080'});
+      var zosconnect = new ZosConnect({ uri:'http://test:9080' });
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
                 .reply(200, {
@@ -128,7 +128,7 @@ describe('zosconnect', function() {
     });
 
     it('should return an error for unknown service', function(done) {
-      var zosconnect = new ZosConnect({uri:'http://test:9080'});
+      var zosconnect = new ZosConnect({ uri:'http://test:9080' });
       nock('http://test:9080')
           .get('/zosConnect/services/unknown')
           .reply(404);
@@ -140,7 +140,7 @@ describe('zosconnect', function() {
     });
 
     it('should return an error for network error', function(done) {
-      var zosconnect = new ZosConnect({uri:'http://test:9080'});
+      var zosconnect = new ZosConnect({ uri:'http://test:9080' });
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
           .replyWithError('something fatal occurred');

--- a/test/service.js
+++ b/test/service.js
@@ -21,13 +21,13 @@ var url = require('url');
 
 var Service = require('../service.js');
 describe('service', function() {
-  var dateTimeService = new Service({uri: 'http://test:9080/zosConnect/services/dateTimeService'}, 'dateTimeService', 'http://test:9080/zosConnect/services/dateTimeService?action=invoke');
+  var dateTimeService = new Service({ uri: 'http://test:9080/zosConnect/services/dateTimeService' }, 'dateTimeService', 'http://test:9080/zosConnect/services/dateTimeService?action=invoke');
   describe('#invoke', function() {
     it('should invoke the service', function(done) {
       nock('http://test:9080')
           .put('/zosConnect/services/dateTimeService')
-          .query({action:'invoke'})
-          .reply(200, {time:'2:32:01 PM', config:'', date:'Sep 4, 2015'});
+          .query({ action:'invoke' })
+          .reply(200, { time:'2:32:01 PM', config:'', date:'Sep 4, 2015' });
       dateTimeService.invoke('', function(error, response, body) {
         should.not.exist(error);
         response.statusCode.should.equal(200);
@@ -39,7 +39,7 @@ describe('service', function() {
     it('should return a security error', function(done) {
       nock('http://test:9080')
           .put('/zosConnect/services/dateTimeService')
-          .query({action:'invoke'})
+          .query({ action:'invoke' })
           .reply(401);
       dateTimeService.invoke('', function(error, response, body) {
         should.not.exist(error);
@@ -52,7 +52,7 @@ describe('service', function() {
     it('should return an error', function(done) {
       nock('http://test:9080')
           .put('/zosConnect/services/dateTimeService')
-          .query({action:'invoke'})
+          .query({ action:'invoke' })
           .replyWithError('something fatal happened');
       dateTimeService.invoke('', function(error, response, body) {
         should.exist(error);
@@ -67,7 +67,7 @@ describe('service', function() {
     it('should retrieve the request schema', function(done) {
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
-          .query({action:'getRequestSchema'})
+          .query({ action:'getRequestSchema' })
           .reply(200, {});
       dateTimeService.getRequestSchema(function(error, schema) {
         should.not.exist(error);
@@ -79,7 +79,7 @@ describe('service', function() {
     it('should return a security error', function(done) {
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
-          .query({action:'getRequestSchema'})
+          .query({ action:'getRequestSchema' })
           .reply(401);
       dateTimeService.getRequestSchema(function(error, schema) {
         should.exist(error);
@@ -91,7 +91,7 @@ describe('service', function() {
     it('should return an error', function(done) {
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
-          .query({action:'getRequestSchema'})
+          .query({ action:'getRequestSchema' })
           .replyWithError('something fatal happened');
       dateTimeService.getRequestSchema(function(error, schema) {
         should.exist(error);
@@ -105,8 +105,8 @@ describe('service', function() {
     it('should retrieve the response schema', function(done) {
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
-          .query({action:'getResponseSchema'})
-          .reply(200, {title:'Reference Schema', properties:{time:{type:'string'}, date:{type:'string'}}, required:['date', 'time'], type:'object'});
+          .query({ action:'getResponseSchema' })
+          .reply(200, { title:'Reference Schema', properties:{ time:{ type:'string' }, date:{ type:'string' } }, required:['date', 'time'], type:'object' });
       dateTimeService.getResponseSchema(function(error, schema) {
         should.not.exist(error);
         should.exist(schema);
@@ -117,7 +117,7 @@ describe('service', function() {
     it('should return a security error', function(done) {
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
-          .query({action:'getResponseSchema'})
+          .query({ action:'getResponseSchema' })
           .reply(401);
       dateTimeService.getResponseSchema(function(error, schema) {
         should.exist(error);
@@ -129,7 +129,7 @@ describe('service', function() {
     it('should return an error', function(done) {
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
-          .query({action:'getResponseSchema'})
+          .query({ action:'getResponseSchema' })
           .replyWithError('something fatal happened');
       dateTimeService.getResponseSchema(function(error, schema) {
         should.exist(error);
@@ -143,8 +143,8 @@ describe('service', function() {
     it('should return the status', function(done) {
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
-          .query({action:'status'})
-          .reply(200, {zosConnect:{dataXformProvider:'DATA_UNAVAILABLE', serviceDescription:'Get the date and time from the server', serviceInvokeURL:'http://192.168.99.100:9080/zosConnect/services/dateTimeService?action=invoke', serviceName:'dateTimeService', serviceProvider:'zOSConnect Reference Service Provider', serviceStatus:'Started', serviceURL:'http://192.168.99.100:9080/zosConnect/services/dateTimeService'}});
+          .query({ action:'status' })
+          .reply(200, { zosConnect:{ dataXformProvider:'DATA_UNAVAILABLE', serviceDescription:'Get the date and time from the server', serviceInvokeURL:'http://192.168.99.100:9080/zosConnect/services/dateTimeService?action=invoke', serviceName:'dateTimeService', serviceProvider:'zOSConnect Reference Service Provider', serviceStatus:'Started', serviceURL:'http://192.168.99.100:9080/zosConnect/services/dateTimeService' } });
       dateTimeService.getStatus(function(error, status) {
         should.not.exist(error);
         status.should.equal('Started');
@@ -155,7 +155,7 @@ describe('service', function() {
     it('should return a security error', function(done) {
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
-          .query({action:'status'})
+          .query({ action:'status' })
           .reply(401);
       dateTimeService.getStatus(function(error, schema) {
         should.exist(error);
@@ -167,7 +167,7 @@ describe('service', function() {
     it('should return an error', function(done) {
       nock('http://test:9080')
           .get('/zosConnect/services/dateTimeService')
-          .query({action:'status'})
+          .query({ action:'status' })
           .replyWithError('something fatal happened');
       dateTimeService.getStatus(function(error, schema) {
         should.exist(error);


### PR DESCRIPTION
JSCS is now at 2.8.0 and enforces extra whitespace after { and before } which the tests are falling foul of. Updating the test syntax to ensure clean CI builds in Travis.

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>