### PR TITLE
Allow access to z/OS Connect via proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+.vscode/

--- a/api.js
+++ b/api.js
@@ -16,6 +16,7 @@
 
 const request = require('request');
 const extend = require('extend');
+const { URL } = require('url');
 
 module.exports = function API(options, apiName, basePath, documentation) {
   this.options = options;
@@ -29,8 +30,10 @@ module.exports = function API(options, apiName, basePath, documentation) {
     if (documentationUri === undefined) {
       return Promise.reject('Documentation not available');
     }
+    const docUrl = new URL(documentationUri);
+    const apiUrl = new URL(this.basePath);
     opOptions = extend(opOptions, this.options);
-    opOptions.uri = documentationUri;
+    opOptions.uri = `${apiUrl.origin}${docUrl.pathname}`;
     return new Promise(((resolve, reject) => {
       request.get(opOptions, (error, response, body) => {
         if (error !== null) {

--- a/index.js
+++ b/index.js
@@ -79,7 +79,9 @@ module.exports = function ZosConnect(options) {
           reject(new Error(`Unable to get service (${response.statusCode})`));
         } else {
           const serviceData = JSON.parse(body);
-          resolve(new Service(opOptions, serviceName, serviceData.zosConnect.serviceInvokeURL));
+          const invokeUrl = new URL(serviceData.zosConnect.serviceInvokeURL);
+          resolve(new Service(opOptions, serviceName,
+            this.options.uri + invokeUrl.pathname + invokeUrl.search));
         }
       });
     }));

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const request = require('request');
 const extend = require('extend');
 const Service = require('./service.js');
 const Api = require('./api.js');
+const { URL } = require('url');
 
 const defaultOptions = {
   strictSSL: true,
@@ -100,7 +101,6 @@ module.exports = function ZosConnect(options) {
           for (const api of json.apis) {
             apis.push(api.name);
           }
-
           resolve(apis);
         }
       });
@@ -119,7 +119,9 @@ module.exports = function ZosConnect(options) {
           reject(new Error(`Unable to get API information (${response.statusCode})`));
         } else {
           const json = JSON.parse(body);
-          resolve(new Api(opOptions, apiName, json.apiUrl, json.documentation));
+          const apiUrl = new URL(json.apiUrl);
+          resolve(new Api(opOptions, apiName, this.options.uri + apiUrl.pathname,
+            json.documentation));
         }
       });
     }));
@@ -142,7 +144,9 @@ module.exports = function ZosConnect(options) {
           reject(new Error(`Unable to create API (${response.statusCode})`));
         } else {
           const json = JSON.parse(body);
-          resolve(new Api(opOptions, json.name, json.apiUrl, json.documentation));
+          const apiUrl = new URL(json.apiUrl);
+          resolve(new Api(opOptions, json.name, this.options.uri + apiUrl.pathname,
+            json.documentation));
         }
       });
     }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zosconnect-node",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Node zosconnect",
     "main": "index.js",
     "dependencies": {


### PR DESCRIPTION
Resolves #24 by using the connection details from the initial connection to override what's returned in the responses from z/OS Connect EE.

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>